### PR TITLE
aezeed: update genesis date.

### DIFF
--- a/aezeed/README.md
+++ b/aezeed/README.md
@@ -46,8 +46,8 @@ desirable features. First, we start with the following plaintext seed:
 The version field is for wallets to be able to know how to re-derive
 the keys of the wallet.
 
-The 2 byte timestamp is expressed in Bitcoin Days Genesis, meaning that
-the number of days since the timestamp in Bitcoin’s genesis block. This
+The 2 byte timestamp is expressed in Decred Days Genesis, meaning that
+the number of days since the timestamp in Decred’s genesis block. This
 allow us to save space, and also avoid using a wasteful level of
 granularity. With the currently, this can express time up until 2188.
 

--- a/aezeed/cipherseed.go
+++ b/aezeed/cipherseed.go
@@ -19,7 +19,7 @@ const (
 	// CipherSeedVersion is the current version of the aezeed scheme as
 	// defined in this package. This version indicates the following
 	// parameters for the deciphered cipher seed: a 1 byte version, 2 bytes
-	// for the Bitcoin Days Genesis timestamp, and 16 bytes for entropy. It
+	// for the Decred Days Genesis timestamp, and 16 bytes for entropy. It
 	// also governs how the cipher seed should be enciphered. In this
 	// version we take the deciphered seed, create a 5 byte salt, use that
 	// with an optional passphrase to generate a 32-byte key (via scrypt),
@@ -34,7 +34,7 @@ const (
 	//  * 1 byte version || 2 bytes timestamp || 16 bytes of entropy.
 	//
 	// The version is used by wallets to know how to re-derive relevant
-	// addresses, the 2 byte timestamp a BDG (Bitcoin Days Genesis) offset,
+	// addresses, the 2 byte timestamp a DDG (Decred Days Genesis) offset,
 	// and finally, the 16 bytes to be used to generate the HD wallet seed.
 	DecipheredCipherSeedSize = 19
 
@@ -126,12 +126,12 @@ var (
 )
 
 var (
-	// BitcoinGenesisDate is the timestamp of Bitcoin's genesis block.
+	// DecredGenesisDate is the timestamp of Decred's genesis block.
 	// We'll use this value in order to create a compact birthday for the
 	// seed. The birthday will be interested as the number of days since
-	// the genesis date. We refer to this time period as ABE (after Bitcoin
+	// the genesis date. We refer to this time period as ADE (after Decred
 	// era).
-	BitcoinGenesisDate = time.Unix(1231006505, 0)
+	DecredGenesisDate = time.Unix(1454954400, 0)
 )
 
 // CipherSeed is a fully decoded instance of the aezeed scheme. At a high
@@ -163,7 +163,7 @@ type CipherSeed struct {
 	InternalVersion uint8
 
 	// Birthday is the time that the seed was created. This is expressed as
-	// the number of days since the timestamp in the Bitcoin genesis block.
+	// the number of days since the timestamp in the Decred genesis block.
 	// We use days as seconds gives us wasted granularity. The oldest seed
 	// that we can encode using this format is through the date 2188.
 	Birthday uint16
@@ -199,9 +199,9 @@ func New(internalVersion uint8, entropy *[EntropySize]byte,
 	}
 
 	// To compute our "birthday", we'll first use the current time, then
-	// subtract that from the Bitcoin Genesis Date. We'll then convert that
+	// subtract that from the Decred Genesis Date. We'll then convert that
 	// value to days.
-	birthday := uint16(now.Sub(BitcoinGenesisDate) / (time.Hour * 24))
+	birthday := uint16(now.Sub(DecredGenesisDate) / (time.Hour * 24))
 
 	c := &CipherSeed{
 		InternalVersion: internalVersion,
@@ -388,7 +388,7 @@ func (c *CipherSeed) Encipher(pass []byte) ([EncipheredCipherSeedSize]byte, erro
 // golang Time struct.
 func (c *CipherSeed) BirthdayTime() time.Time {
 	offset := time.Duration(c.Birthday) * 24 * time.Hour
-	return BitcoinGenesisDate.Add(offset)
+	return DecredGenesisDate.Add(offset)
 }
 
 // Mnemonic is a 24-word passphrase as of CipherSeedVersion zero. This

--- a/aezeed/cipherseed_test.go
+++ b/aezeed/cipherseed_test.go
@@ -33,7 +33,7 @@ var (
 	version0TestVectors = []TestVector{
 		{
 			version:  0,
-			time:     BitcoinGenesisDate,
+			time:     DecredGenesisDate,
 			entropy:  testEntropy,
 			salt:     testSalt,
 			password: []byte{},
@@ -52,12 +52,12 @@ var (
 			salt:     testSalt,
 			password: []byte("!very_safe_55345_password*"),
 			expectedMnemonic: [NummnemonicWords]string{
-				"able", "tree", "stool", "crush", "transfer", "cloud",
-				"cross", "three", "profit", "outside", "hen", "citizen",
-				"plate", "ride", "require", "leg", "siren", "drum",
-				"success", "suggest", "drink", "require", "fiscal", "upgrade",
+				"absorb", "life", "portion", "oxygen", "stock", "pottery",
+				"soup", "build", "ugly", "jeans", "small", "uniform",
+				"letter", "voyage", "spirit", "age", "fury", "entire",
+				"success", "suggest", "drink", "office", "view", "dizzy",
 			},
-			expectedBirthday: 3365,
+			expectedBirthday: 773,
 		},
 	}
 )
@@ -466,7 +466,7 @@ func TestSeedEncodeDecode(t *testing.T) {
 		now := time.Unix(nowInt, 0)
 		seed := CipherSeed{
 			InternalVersion: version,
-			Birthday:        uint16(now.Sub(BitcoinGenesisDate) / (time.Hour * 24)),
+			Birthday:        uint16(now.Sub(DecredGenesisDate) / (time.Hour * 24)),
 			Entropy:         entropy,
 		}
 


### PR DESCRIPTION
This switches the genesis date referenced from bitcoin to decred, updates documentation and call sites as well as tests.